### PR TITLE
fix copy of arrays generation in __copyOut

### DIFF
--- a/src/api/dcps/isocpp/include/dds/pub/discovery.hpp
+++ b/src/api/dcps/isocpp/include/dds/pub/discovery.hpp
@@ -66,7 +66,7 @@ matched_subscriptions(const dds::pub::DataWriter<T>& dw,
     DDS::ReturnCode_t result = ((dds::pub::DataWriter<T>)dw)->get_raw_writer()->get_matched_subscriptions(ddsSeq);
     org::opensplice::core::check_and_throw(result, OSPL_CONTEXT_LITERAL("Calling ::get_matched_subscriptions"));
 
-    ddsSeq.length() < max_size ? max_size = ddsSeq.length() : max_size = max_size;
+    max_size = ddsSeq.length() < max_size ? ddsSeq.length() : max_size;
 
     for(uint32_t i = 0; i < max_size; i++)
     {

--- a/src/api/dcps/isocpp/include/dds/sub/discovery.hpp
+++ b/src/api/dcps/isocpp/include/dds/sub/discovery.hpp
@@ -66,7 +66,7 @@ matched_publications(const dds::sub::DataReader<T>& dr,
     DDS::ReturnCode_t result = ((dds::sub::DataReader<T>)dr)->get_raw_reader()->get_matched_publications(ddsSeq);
     org::opensplice::core::check_and_throw(result, OSPL_CONTEXT_LITERAL("Calling ::get_matched_publications"));
 
-    ddsSeq.length() < max_size ? max_size = ddsSeq.length() : max_size = max_size;
+    max_size = ddsSeq.length() < max_size ? ddsSeq.length() : max_size;
 
     for(uint32_t i = 0; i < max_size; i++)
     {

--- a/src/tools/idlpp/code/idl_genCorbaCxxCopyout.c
+++ b/src/tools/idlpp/code/idl_genCorbaCxxCopyout.c
@@ -1165,7 +1165,7 @@ idl_arrayElements(
                 os_free(buf);
             } else {
             	idl_printIndent(indent);
-                idl_fileOutPrintf(idl_fileCur(), "    memcpy (%s, %s, sizeof (%s));\n", to, from, to);
+                idl_fileOutPrintf(idl_fileCur(), "    memcpy (%s, %s, sizeof (*%s));\n", to, from, from);
             }
             /* QAC EXPECT 3416; No side effect here */
         } else if (idl_typeSpecType(idl_typeDefActual(idl_typeDef(subType))) == idl_tenum) {


### PR DESCRIPTION
fixes array copies, the previous code would only copy the size of a pointer
also some crazy ternary statement which generates many warnings
