### PR TITLE
Update os_heap.h

### DIFF
--- a/src/abstraction/os/include/os_heap.h
+++ b/src/abstraction/os/include/os_heap.h
@@ -81,7 +81,7 @@ os_realloc(
     void *memblk,
     os_size_t size) __attribute_returns_nonnull__
                     __attribute_warn_unused_result__
-                    __attribute_alloc_size__((1));
+                    __attribute_alloc_size__((2));
 
 /** \brief Free allocated memory and return it to heap
  *


### PR DESCRIPTION
Fix for #37 : Opensplice 6.7 triggers internal compiler error with gcc 7.1