### PR TITLE
Add userData to instance

### DIFF
--- a/setup/x86.linux-default.mak
+++ b/setup/x86.linux-default.mak
@@ -19,7 +19,7 @@ MAKE		 = make
 	# Solaris native touch
 TOUCH		 = touch
 	# Tool used for creating soft/hard links.
-LN               = ln
+LN               = ln -s
 	# Archiving
 AR               = /usr/bin/ar
 # Archiver when using link-time optimizations

--- a/setup/x86_64.linux-default.mak
+++ b/setup/x86_64.linux-default.mak
@@ -19,7 +19,7 @@ MAKE		 = make
 	# Solaris native touch
 TOUCH		 = touch
 	# Tool used for creating soft/hard links.
-LN               = ln
+LN               = ln -s
 	# Archiving
 AR               = /usr/bin/ar
 # Archiver when using link-time optimizations

--- a/setup/x86_64.linux_clang-default.mak
+++ b/setup/x86_64.linux_clang-default.mak
@@ -19,7 +19,7 @@ MAKE		 = make
 	# Solaris native touch
 TOUCH		 = touch
 	# Tool used for creating soft/hard links.
-LN               = ln
+LN               = ln -s
 	# Archiving
 AR               = /usr/bin/ar
 AR_CMDS          = rv

--- a/setup/x86_64.linux_opencc-default.mak
+++ b/setup/x86_64.linux_opencc-default.mak
@@ -19,7 +19,7 @@ MAKE		 = make
 	# Solaris native touch
 TOUCH		 = touch
 	# Tool used for creating soft/hard links.
-LN               = ln
+LN               = ln -s
 	# Archiving
 AR               = /usr/bin/ar
 AR_CMDS          = rv

--- a/src/kernel/code/v_kernel.odl
+++ b/src/kernel/code/v_kernel.odl
@@ -1905,6 +1905,7 @@ class v_orderedInstanceSample extends v_dataViewSample {
         attribute c_bool                         inNotEmptyList;
         attribute os_timeE                       lastInsertionTime;
         attribute v_dataReaderSampleTemplate     pending;
+        attribute c_voidp                        userData;
     };
 
     class v_orderedInstance extends v_dataViewInstanceTemplate {


### PR DESCRIPTION
This PR contains two commits:
- Add a “userData” field to a datareader instance. This makes it easier to bind DDS instances with local representations without doing expensive lookups.
- Create softlinks instead of hardlinks when building the source. When building on a VM on a host that runs a filesystem which does not support hardlinks, a build will fail.